### PR TITLE
fix antialiasing on non-retina display

### DIFF
--- a/ARCollectionViewMasonryLayout.m
+++ b/ARCollectionViewMasonryLayout.m
@@ -236,8 +236,8 @@
         CGFloat yOffset = [self.internalDimensions[columnIndex] floatValue];
 
         CGPoint itemCenter = (CGPoint){
-            floorf(xOffset + (self.dimensionLength / 2)),
-            floorf(yOffset + (itemAlternateDimension/2))
+            xOffset + (self.dimensionLength / 2),
+            yOffset + (itemAlternateDimension/2)
         };
 
         UICollectionViewLayoutAttributes *attributes = [UICollectionViewLayoutAttributes layoutAttributesForCellWithIndexPath:indexPath];
@@ -251,6 +251,7 @@
         }
 
         attributes.center = itemCenter;
+        attributes.frame = CGRectIntegral(attributes.frame);
         [self.itemAttributes addObject:attributes];
 
         // Ensure an extra margin is not applied


### PR DESCRIPTION
I noticed that on a non-retina iPad there was some anti-aliasing going on. This is because the center point was being rounded to integer pixels rather than the origin. For items with an odd width, the center point should in fact be a half pixel. Flooring the center offsets the frame by 0.5 pixels, which is the opposite of what we want. Items with an even width don't have this problem because their center and origin will always fall on an integer.

Here's how it looks
![screen shot 2014-05-08 at 5 24 38 pm](https://cloud.githubusercontent.com/assets/3171662/2921698/2e342948-d6f7-11e3-9dbe-2e9cdbb880e5.png)

Logging some values right before adding `attributes` to `itemAttributes` produced the following, which confirms the above:

``` objective-c
x origin: 291.000000, width: 466.000000, center x: 524.000000
x origin: 407.500000, width: 301.000000, center x: 558.000000
x origin: 724.000000, width: 150.000000, center x: 799.000000
x origin: 771.500000, width: 159.000000, center x: 851.000000
x origin: 888.500000, width: 241.000000, center x: 1009.000000
x origin: 945.500000, width: 137.000000, center x: 1014.000000
```

Instead of flooring the center, which I assume was intended to prevent blurring, I tried using CGRectIntegral and everything looks good.

``` objective-c
x origin: 291.000000, width: 466.000000, center x: 524.000000
x origin: 408.000000, width: 301.000000, center x: 558.500000
x origin: 724.000000, width: 150.000000, center x: 799.000000
x origin: 772.000000, width: 159.000000, center x: 851.500000
x origin: 889.000000, width: 241.000000, center x: 1009.500000
x origin: 946.000000, width: 137.000000, center x: 1014.500000
```
