### PR TITLE
@ashfurrow => support for returning layout attributes for header and footer

### DIFF
--- a/ARCollectionViewMasonryLayout.m
+++ b/ARCollectionViewMasonryLayout.m
@@ -378,13 +378,14 @@
 
 - (NSArray *)layoutAttributesForElementsInRect:(CGRect)rect
 {
-    NSMutableArray *attributes = [self.itemAttributes mutableCopy];
+    NSArray *attributes = self.itemAttributes;
     if (self.headerAttributes) {
-        [attributes addObject:self.headerAttributes];
+        attributes = [attributes arrayByAddingObject:self.headerAttributes];
     }
     if (self.footerAttributes) {
-        [attributes addObject:self.footerAttributes];
+        attributes = [attributes arrayByAddingObject:self.footerAttributes];
     }
+
     return [attributes filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
         return CGRectIntersectsRect(rect, [evaluatedObject frame]);
     }]];


### PR DESCRIPTION
Here I did what we talked about. header and footer attributes are calculated if necessary and stored. they are  can then be included when determining which attributes to return for `layoutAttributesForElementsInRect` and `layoutAttributesForSupplementaryViewOfKind`.
