### PR TITLE
Fixed multiple sections false positive assert in longestDimensionWithLengths when invoked without a collection view.

### DIFF
--- a/ARCollectionViewMasonryLayout.m
+++ b/ARCollectionViewMasonryLayout.m
@@ -135,7 +135,10 @@
 
 - (CGFloat)longestDimensionWithLengths:(NSArray *)variableDimensions withOppositeDimension:(CGFloat)staticDimension;
 {
-    [self setupLayoutWithStaticDimension:staticDimension andVariableDimensions:variableDimensions];
+    if ([self collectionView]) {
+        [self setupLayoutWithStaticDimension:staticDimension andVariableDimensions:variableDimensions];
+    }
+    
     if ([self isHorizontal]) {
         return  [self collectionViewContentSize].width;
     } else {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Next
 ----
-- [#16](https://github.com/AshFurrow/ARCollectionViewMasonryLayout/pull/16): Changed ARCollectionViewMasonryLayout to use UICollectionViewFlowLayout's API and support for headers and footers. - [@laurabrown](https://github.com/1aurabrown).
+
+- [#16](https://github.com/AshFurrow/ARCollectionViewMasonryLayout/pull/16): Changed ARCollectionViewMasonryLayout to use UICollectionViewFlowLayout's API and support for headers and footers - [@laurabrown](https://github.com/1aurabrown).
+- [#20](https://github.com/AshFurrow/ARCollectionViewMasonryLayout/pull/20): Fixed multiple sections false positive assert in `longestDimensionWithLengths` when invoked without a collection view - [@dblock](https://github.com/dblock).
 
 1.0.0
 ----

--- a/IntegrationTests/ARCollectionViewMasonryLayoutTests.m
+++ b/IntegrationTests/ARCollectionViewMasonryLayoutTests.m
@@ -26,7 +26,7 @@ describe(@"horizontal layout", ^{
         expect(layout.collectionViewContentSize.width).to.equal(0);
     });
     
-    it (@"has the correct horizontal direction", ^{
+    it(@"has the correct horizontal direction", ^{
         expect(layout.direction).to.equal(ARCollectionViewMasonryLayoutDirectionHorizontal);
     });
     
@@ -146,6 +146,16 @@ describe(@"vertical layout", ^{
         expect(viewController.view).willNot.beNil();
         expect(viewController.view).will.haveValidSnapshotNamed(@"verticalWithHeaderAndFooter");
         expect(layout.collectionViewContentSize.height).to.equal(135);
+    });
+});
+
+describe(@"longestDimensionWithLengths", ^{
+    beforeEach(^{
+        layout = [[ARCollectionViewMasonryLayout alloc] initWithDirection:ARCollectionViewMasonryLayoutDirectionHorizontal];
+    });
+    
+    it(@"returns zero without a view", ^{
+        expect([layout longestDimensionWithLengths:@[] withOppositeDimension:0]).to.equal(0);
     });
 });
 


### PR DESCRIPTION
The problem is that `setupLayoutWithStaticDimension:andVariableDimensions` will assert if you have != 1 section in the collection view. If there's no collection view, you get zero. 

```
2014-06-30 09:31:12.517 Artsy[62742:60b] *** Assertion failure in -[ARCollectionViewMasonryLayout setupLayoutWithStaticDimsion:andVaribleDimensions:], /Users/dblock/source/eigen/dblock/Pods/ARCollectionViewMasonryLayout/ARCollectionViewMasonryLayout.m:148
2014-06-30 09:31:12.624 Artsy[62742:60b] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'ARCollectionViewmMasonry doesn't support multiple sections.'
*** First throw call stack:
(
    0   CoreFoundation                      0x031ec1e4 __exceptionPreprocess + 180
    1   libobjc.A.dylib                     0x02e038e5 objc_exception_throw + 44
    2   CoreFoundation                      0x031ec048 +[NSException raise:format:arguments:] + 136
    3   Foundation                          0x012074de -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:] + 116
    4   Artsy                               0x00250532 -[ARCollectionViewMasonryLayout setupLayoutWithStaticDimsion:andVaribleDimensions:] + 658
    5   Artsy                               0x002501f4 -[ARCollectionViewMasonryLayout longestDimensionWithLengths:withOppositeDimension:] + 116
    6   Artsy                               0x00115848 +[ARArtworkMasonryModule intrinsicSizeWithWithLayout:style:andArtworks:] + 1448
    7   Artsy                               0x00115d27 -[ARArtworkMasonryModule intrinsicSize] + 183
```
