### PR TITLE
Fix content size when empty

### DIFF
--- a/ARCollectionViewMasonryLayout.m
+++ b/ARCollectionViewMasonryLayout.m
@@ -85,7 +85,9 @@
         for (int i = 0; i < itemCount; i++) {
             NSIndexPath *indexPath = [NSIndexPath indexPathForItem:i inSection:0];
 
-            CGFloat variableDimension = [self.delegate collectionView:self.collectionView layout:self variableDimensionForItemAtIndexPath:indexPath];
+            CGFloat variableDimension = [self.delegate collectionView:self.collectionView
+                                                               layout:self
+                                  variableDimensionForItemAtIndexPath:indexPath];
 
             [variableDimensions addObject:@(variableDimension)];
         }
@@ -273,10 +275,17 @@
 - (CGSize)collectionViewContentSize
 {
     NSIndexPath *indexPathZero = [NSIndexPath indexPathForItem:0 inSection:0];
+    BOOL isHorizontal = self.isHorizontal;
     CGFloat alternateDimension = 0;
 
     if (self.itemCount > 0) {
         alternateDimension = self.attributesGrid.longestSectionDimension;
+        // Add trailing inset/margin
+        if (isHorizontal) {
+            alternateDimension += (self.hasContentInset ? self.contentInset.right : self.itemMargins.width);
+        } else {
+            alternateDimension += (self.hasContentInset ? self.contentInset.bottom : self.itemMargins.height);
+        }
     } else {
         // Only the header.
         CGFloat headerHeight = [self headerDimensionAtIndexPath:indexPathZero];
@@ -289,16 +298,6 @@
     CGFloat footerHeight = [self footerDimensionAtIndexPath:indexPathZero];
     if (footerHeight != NSNotFound) {
         alternateDimension += footerHeight;
-    }
-
-    BOOL isHorizontal = self.isHorizontal;
-    BOOL hasContentInset = self.hasContentInset;
-
-    // Add trailing inset
-    if (isHorizontal) {
-        alternateDimension += (hasContentInset ? self.contentInset.right : self.itemMargins.width);
-    } else {
-        alternateDimension += (hasContentInset ? self.contentInset.bottom : self.itemMargins.height);
     }
 
     CGSize contentSize = self.collectionView.frame.size;

--- a/ARCollectionViewMasonryLayout.podspec
+++ b/ARCollectionViewMasonryLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = "ARCollectionViewMasonryLayout"
-  s.version             = "2.1.0"
+  s.version             = "2.1.1"
   s.summary             = "ARCollectionViewMasonryLayout is a UICollectionViewLayout subclass for creating flow-like layouts with dynamic widths or heights."
   s.homepage            = "https://github.com/AshFurrow/ARCollectionViewMasonryLayout"
   s.screenshots         = "https://raw.githubusercontent.com/AshFurrow/ARCollectionViewMasonryLayout/master/Screenshots/ARCollectionViewMasonryLayout.png"

--- a/IntegrationTests/ARCollectionViewMasonryLayoutTests.m
+++ b/IntegrationTests/ARCollectionViewMasonryLayoutTests.m
@@ -199,6 +199,15 @@ describe(@"horizontal layout", ^{
         expect(viewController.view).willNot.beNil();
         expect(viewController.view).will.haveValidSnapshotNamed(@"horizontalWithMarginsAndInsets");
     });
+
+    it(@"reports correct content size", ^{
+        layout.itemMargins = CGSizeMake(10, 20);
+        layout.contentInset = UIEdgeInsetsMake(10, 20, 10, 20);
+        layout.sectionInset = UIEdgeInsetsMake(10, 20, 10, 20);
+        ARCollectionViewController *viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
+        viewController.colorCount = 0;
+        expect(layout.collectionViewContentSize).to.equal(CGSizeZero);
+    });
 });
 
 describe(@"vertical layout", ^{
@@ -272,6 +281,15 @@ describe(@"vertical layout", ^{
         viewController.colorCount = 4;
         expect(viewController.view).willNot.beNil();
         expect(viewController.view).will.haveValidSnapshotNamed(@"verticalWithMarginsAndInsets");
+    });
+
+    it(@"reports correct content size", ^{
+        layout.itemMargins = CGSizeMake(10, 20);
+        layout.contentInset = UIEdgeInsetsMake(10, 20, 10, 20);
+        layout.sectionInset = UIEdgeInsetsMake(10, 20, 10, 20);
+        ARCollectionViewController *viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
+        viewController.colorCount = 0;
+        expect(layout.collectionViewContentSize).to.equal(CGSizeZero);
     });
 });
 

--- a/IntegrationTests/ARCollectionViewMasonryLayoutTests.m
+++ b/IntegrationTests/ARCollectionViewMasonryLayoutTests.m
@@ -118,10 +118,12 @@ describe(@"_ARCollectionViewMasonryAttributesGrid", ^{
 });
 
 __block ARCollectionViewMasonryLayout *layout = nil;
+__block ARCollectionViewController *viewController = nil;
 
 describe(@"horizontal layout", ^{
     beforeEach(^{
         layout = [[ARCollectionViewMasonryLayout alloc] initWithDirection:ARCollectionViewMasonryLayoutDirectionHorizontal];
+        viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
     });
     
     it(@"has default values when initialized", ^{
@@ -137,7 +139,6 @@ describe(@"horizontal layout", ^{
     });
     
     it(@"displays cells", ^{
-        ARCollectionViewController *viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
         viewController.colorCount = 5;
         expect(viewController.view).willNot.beNil();
         expect(viewController.view).will.haveValidSnapshotNamed(@"horizontal");
@@ -145,7 +146,6 @@ describe(@"horizontal layout", ^{
     });
     
     it(@"displays footer", ^{
-        ARCollectionViewController *viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
         viewController.footerSize = CGSizeMake(20, 0);
         viewController.colorCount = 7;
         expect(viewController.view).willNot.beNil();
@@ -154,7 +154,6 @@ describe(@"horizontal layout", ^{
     });
 
     it(@"displays footer only", ^{
-        ARCollectionViewController *viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
         viewController.footerSize = CGSizeMake(20, 0);
         viewController.colorCount = 0;
         expect(viewController.view).willNot.beNil();
@@ -163,7 +162,6 @@ describe(@"horizontal layout", ^{
     });
 
     it(@"displays header", ^{
-        ARCollectionViewController *viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
         viewController.headerSize = CGSizeMake(10, 0);
         viewController.colorCount = 4;
         expect(viewController.view).willNot.beNil();
@@ -172,7 +170,6 @@ describe(@"horizontal layout", ^{
     });
 
     it(@"displays header only", ^{
-        ARCollectionViewController *viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
         viewController.headerSize = CGSizeMake(10, 0);
         viewController.colorCount = 0;
         expect(viewController.view).willNot.beNil();
@@ -181,7 +178,6 @@ describe(@"horizontal layout", ^{
     });
 
     it(@"displays header and footer", ^{
-        ARCollectionViewController *viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
         viewController.headerSize = CGSizeMake(3, 0);
         viewController.footerSize = CGSizeMake(5, 0);
         viewController.colorCount = 4;
@@ -190,29 +186,30 @@ describe(@"horizontal layout", ^{
         expect(layout.collectionViewContentSize.width).to.equal(108);
     });
 
-    it(@"applies correct margins and insets", ^{
-        layout.itemMargins = CGSizeMake(10, 20);
-        layout.contentInset = UIEdgeInsetsMake(10, 20, 10, 20);
-        layout.sectionInset = UIEdgeInsetsMake(10, 20, 10, 20);
-        ARCollectionViewController *viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
-        viewController.colorCount = 4;
-        expect(viewController.view).willNot.beNil();
-        expect(viewController.view).will.haveValidSnapshotNamed(@"horizontalWithMarginsAndInsets");
-    });
+    describe(@"with margins and insets", ^{
+        beforeEach(^{
+            layout.itemMargins = CGSizeMake(10, 20);
+            layout.contentInset = UIEdgeInsetsMake(10, 20, 10, 20);
+            layout.sectionInset = UIEdgeInsetsMake(10, 20, 10, 20);
+        });
 
-    it(@"reports correct content size", ^{
-        layout.itemMargins = CGSizeMake(10, 20);
-        layout.contentInset = UIEdgeInsetsMake(10, 20, 10, 20);
-        layout.sectionInset = UIEdgeInsetsMake(10, 20, 10, 20);
-        ARCollectionViewController *viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
-        viewController.colorCount = 0;
-        expect(layout.collectionViewContentSize).to.equal(CGSizeZero);
+        it(@"applies correct margins and insets", ^{
+            viewController.colorCount = 4;
+            expect(viewController.view).willNot.beNil();
+            expect(viewController.view).will.haveValidSnapshotNamed(@"horizontalWithMarginsAndInsets");
+        });
+
+        it(@"reports correct content size", ^{
+            viewController.colorCount = 0;
+            expect(layout.collectionViewContentSize).to.equal(CGSizeZero);
+        });
     });
 });
 
 describe(@"vertical layout", ^{
     beforeEach(^{
         layout = [[ARCollectionViewMasonryLayout alloc] initWithDirection:ARCollectionViewMasonryLayoutDirectionVertical];
+        viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
     });
     
     it(@"has the correct vertical direction", ^{
@@ -220,7 +217,6 @@ describe(@"vertical layout", ^{
     });
     
     it(@"displays cells", ^{
-        ARCollectionViewController *viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
         viewController.colorCount = 7;
         expect(viewController.view).willNot.beNil();
         expect(viewController.view).will.haveValidSnapshotNamed(@"vertical");
@@ -228,7 +224,6 @@ describe(@"vertical layout", ^{
     });
 
     it(@"displays footer", ^{
-        ARCollectionViewController *viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
         viewController.footerSize = CGSizeMake(0, 20);
         viewController.colorCount = 7;
         expect(viewController.view).willNot.beNil();
@@ -237,7 +232,6 @@ describe(@"vertical layout", ^{
     });
 
     it(@"displays footer only", ^{
-        ARCollectionViewController *viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
         viewController.footerSize = CGSizeMake(0, 20);
         viewController.colorCount = 0;
         expect(viewController.view).willNot.beNil();
@@ -246,7 +240,6 @@ describe(@"vertical layout", ^{
     });
 
     it(@"displays header", ^{
-        ARCollectionViewController *viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
         viewController.headerSize = CGSizeMake(0, 10);
         viewController.colorCount = 4;
         expect(viewController.view).willNot.beNil();
@@ -255,7 +248,6 @@ describe(@"vertical layout", ^{
     });
 
     it(@"displays header only", ^{
-        ARCollectionViewController *viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
         viewController.headerSize = CGSizeMake(0, 10);
         viewController.colorCount = 0;
         expect(viewController.view).willNot.beNil();
@@ -264,7 +256,6 @@ describe(@"vertical layout", ^{
     });
 
     it(@"displays header and footer", ^{
-        ARCollectionViewController *viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
         viewController.headerSize = CGSizeMake(0, 30);
         viewController.footerSize = CGSizeMake(0, 5);
         viewController.colorCount = 4;
@@ -273,23 +264,23 @@ describe(@"vertical layout", ^{
         expect(layout.collectionViewContentSize.height).to.equal(135);
     });
 
-    it(@"applies correct margins and insets", ^{
-        layout.itemMargins = CGSizeMake(10, 20);
-        layout.contentInset = UIEdgeInsetsMake(10, 20, 10, 20);
-        layout.sectionInset = UIEdgeInsetsMake(10, 20, 10, 20);
-        ARCollectionViewController *viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
-        viewController.colorCount = 4;
-        expect(viewController.view).willNot.beNil();
-        expect(viewController.view).will.haveValidSnapshotNamed(@"verticalWithMarginsAndInsets");
-    });
+    describe(@"with margins and insets", ^{
+        beforeEach(^{
+            layout.itemMargins = CGSizeMake(10, 20);
+            layout.contentInset = UIEdgeInsetsMake(10, 20, 10, 20);
+            layout.sectionInset = UIEdgeInsetsMake(10, 20, 10, 20);
+        });
 
-    it(@"reports correct content size", ^{
-        layout.itemMargins = CGSizeMake(10, 20);
-        layout.contentInset = UIEdgeInsetsMake(10, 20, 10, 20);
-        layout.sectionInset = UIEdgeInsetsMake(10, 20, 10, 20);
-        ARCollectionViewController *viewController = [[ARCollectionViewController alloc] initWithCollectionViewLayout:layout];
-        viewController.colorCount = 0;
-        expect(layout.collectionViewContentSize).to.equal(CGSizeZero);
+        it(@"applies correct margins and insets", ^{
+            viewController.colorCount = 4;
+            expect(viewController.view).willNot.beNil();
+            expect(viewController.view).will.haveValidSnapshotNamed(@"verticalWithMarginsAndInsets");
+        });
+
+        it(@"reports correct content size", ^{
+            viewController.colorCount = 0;
+            expect(layout.collectionViewContentSize).to.equal(CGSizeZero);
+        });
     });
 });
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ARCollectionViewMasonryLayout (2.1.0)
+  - ARCollectionViewMasonryLayout (2.1.1)
   - EDColor (0.4.0)
   - Expecta (0.3.0)
   - Expecta+Snapshots (1.2.0):
@@ -21,7 +21,7 @@ EXTERNAL SOURCES:
     :path: ARCollectionViewMasonryLayout.podspec
 
 SPEC CHECKSUMS:
-  ARCollectionViewMasonryLayout: 8d8313827f322c00212f50d4f92b442d1a0f1e5d
+  ARCollectionViewMasonryLayout: 98a899a3c9ebf9283e993198e12b54bd3615f672
   EDColor: 89d19a013279a5604d61650721c15f20fefaaf00
   Expecta: 917bda2935b63ca7175741b8cf1b26796db6205f
   Expecta+Snapshots: 9149e6c41878b4f5d603bc18a15716018dee51cd


### PR DESCRIPTION
I was incorrectly including trailing margin in the content size when no items had been layout yet.

Eigen was using the content size (`height == 0`) to decide whether or not to have the collection view calculate its layout and thus was never updated.