### PR TITLE
@ashfurrow -> make sure section dimensions reflect header height even if there are no items

### DIFF
--- a/ARCollectionViewMasonryLayout.m
+++ b/ARCollectionViewMasonryLayout.m
@@ -278,19 +278,15 @@
     BOOL isHorizontal = self.isHorizontal;
     CGFloat alternateDimension = 0;
 
+    // This includes the header height even if there are no items.
+    alternateDimension = self.attributesGrid.longestSectionDimension;
+
     if (self.itemCount > 0) {
-        alternateDimension = self.attributesGrid.longestSectionDimension;
         // Add trailing inset/margin
         if (isHorizontal) {
             alternateDimension += (self.hasContentInset ? self.contentInset.right : self.itemMargins.width);
         } else {
             alternateDimension += (self.hasContentInset ? self.contentInset.bottom : self.itemMargins.height);
-        }
-    } else {
-        // Only the header.
-        CGFloat headerHeight = [self headerDimensionAtIndexPath:indexPathZero];
-        if (headerHeight != NSNotFound) {
-            alternateDimension += headerHeight;
         }
     }
 

--- a/ARCollectionViewMasonryLayout.podspec
+++ b/ARCollectionViewMasonryLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = "ARCollectionViewMasonryLayout"
-  s.version             = "2.1.1"
+  s.version             = "2.1.2"
   s.summary             = "ARCollectionViewMasonryLayout is a UICollectionViewLayout subclass for creating flow-like layouts with dynamic widths or heights."
   s.homepage            = "https://github.com/AshFurrow/ARCollectionViewMasonryLayout"
   s.screenshots         = "https://raw.githubusercontent.com/AshFurrow/ARCollectionViewMasonryLayout/master/Screenshots/ARCollectionViewMasonryLayout.png"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,33 @@
-2.0.0
-----
+Next
+-----
 
-- [#16](https://github.com/AshFurrow/ARCollectionViewMasonryLayout/pull/16): Changed ARCollectionViewMasonryLayout to use UICollectionViewFlowLayout's API and support for headers and footers - [@laurabrown](https://github.com/1aurabrown).
+
+
+2.1.2
+-----
+
+- [#25](https://github.com/ashfurrow/ARCollectionViewMasonryLayout/pull/25): Section dimensions and max attribtue should reflect header height even if items haven't yet been added to the collection view. - [@1aurabrown](https://github.com/1aurabrown)
+
+2.1.1
+-----
+- [#24](https://github.com/ashfurrow/ARCollectionViewMasonryLayout/pull/24): Do not include trailing margin in the content size when the collection view is empty - [@alloy](https://github.com/alloy). 
+
+2.1.0
+-----
+- [#22](remove header and footer attributes if header/footer has no size): Remove header and footer attributes if header/footer has no size - [@laurabrown](https://github.com/1aurabrown).
+- [#23](https://github.com/ashfurrow/ARCollectionViewMasonryLayout/pull/23): Move entries that stick out too far on the wrong side to the front & Move section dimension calculation into a separate class. - [@alloy](https://github.com/alloy).
+
+2.0.0
+-----
 - [#20](https://github.com/AshFurrow/ARCollectionViewMasonryLayout/pull/20): Fixed multiple sections false positive assert in `longestDimensionWithLengths` when invoked without a collection view - [@dblock](https://github.com/dblock).
 
+1.0.1
+-----
+- [#16](https://github.com/AshFurrow/ARCollectionViewMasonryLayout/pull/16): Changed ARCollectionViewMasonryLayout to use UICollectionViewFlowLayout's API and support for headers and footers - [@laurabrown](https://github.com/1aurabrown).
+
+
 1.0.0
-----
+-----
 
 - [#9](https://github.com/AshFurrow/ARCollectionViewMasonryLayout/pull/9): Moved ARCollectionViewMasonryLayout.podspec and screenshots into the project - [@dblock](https://github.com/dblock).
 - [#8](https://github.com/AshFurrow/ARCollectionViewMasonryLayout/issues/8): Added support for header and footer views via `ARCollectionViewMasonryLayoutDelegate` - [@dblock](https://github.com/dblock).

--- a/IntegrationTests/ARCollectionViewMasonryLayoutTests.m
+++ b/IntegrationTests/ARCollectionViewMasonryLayoutTests.m
@@ -6,7 +6,9 @@
 @interface _ARCollectionViewMasonryAttributesGrid (Private)
 @property (nonatomic, readonly, strong) NSArray *sections;
 @property (nonatomic, readonly) NSUInteger shortestSection;
+@property (nonatomic, readonly) CGFloat leadingInset;
 @property (nonatomic, readonly) CGFloat longestSectionDimension;
+@property (nonatomic, readonly) CGFloat shortestSectionDimension;
 - (void)addAttributes:(UICollectionViewLayoutAttributes *)attributes toSection:(NSUInteger)sectionIndex;
 - (CGFloat)dimensionForSection:(NSUInteger)sectionIndex;
 @end
@@ -83,6 +85,35 @@ describe(@"_ARCollectionViewMasonryAttributesGrid", ^{
             expect(grid.longestSectionDimension).to.equal(120); // section 0
             AddLayoutAttributesToSectionWithHeight(grid, 1, 100);
             expect(grid.longestSectionDimension).to.equal(140); // section 1
+        });
+    });
+
+    describe(@"with a leading inset", ^{
+        __block CGFloat headerHeight = 20;
+        before(^{
+            grid = [[_ARCollectionViewMasonryAttributesGrid alloc] initWithSectionCount:3
+                                                                           isHorizontal:NO
+                                                                           leadingInset:headerHeight
+                                                                        orthogonalInset:0
+                                                                         mainItemMargin:0
+                                                                    alternateItemMargin:0
+                                                                        centeringOffset:0];
+        });
+
+        it(@"reflects only the header height if there are no entries", ^{
+            expect(grid.leadingInset).to.equal(headerHeight);
+            expect(grid.longestSectionDimension).to.equal(headerHeight);
+            expect(grid.shortestSectionDimension).to.equal(headerHeight);
+        });
+
+        it(@"reflects the header and entries if there are entries", ^{
+            CGFloat itemHeight = 10;
+
+            AddLayoutAttributesToSectionWithHeight(grid, 0, itemHeight);
+
+            expect(grid.leadingInset).to.equal(headerHeight);
+            expect(grid.longestSectionDimension).to.equal(headerHeight + itemHeight);
+            expect(grid.shortestSectionDimension).to.equal(headerHeight);
         });
     });
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ARCollectionViewMasonryLayout (2.1.1)
+  - ARCollectionViewMasonryLayout (2.1.2)
   - EDColor (0.4.0)
   - Expecta (0.3.0)
   - Expecta+Snapshots (1.2.0):
@@ -21,11 +21,11 @@ EXTERNAL SOURCES:
     :path: ARCollectionViewMasonryLayout.podspec
 
 SPEC CHECKSUMS:
-  ARCollectionViewMasonryLayout: 98a899a3c9ebf9283e993198e12b54bd3615f672
+  ARCollectionViewMasonryLayout: 776730bdedd0c7570a5e904c370e4e120f98ea62
   EDColor: 89d19a013279a5604d61650721c15f20fefaaf00
   Expecta: 917bda2935b63ca7175741b8cf1b26796db6205f
   Expecta+Snapshots: 9149e6c41878b4f5d603bc18a15716018dee51cd
   FBSnapshotTestCase: 892508495a69e8703bab36c9da7674ff740d41db
   Specta: 15a276a6343867b426d5ed135d5aa4d04123a573
 
-COCOAPODS: 0.36.4
+COCOAPODS: 0.37.1

--- a/_ARCollectionViewMasonryAttributesGrid.m
+++ b/_ARCollectionViewMasonryAttributesGrid.m
@@ -33,8 +33,8 @@
         _centeringOffset = centeringOffset;
         _sectionCount = sectionCount;
         _shortestSection = 0;
-        _longestSectionDimension = 0;
-        _shortestSectionDimension = 0;
+        _longestSectionDimension = leadingInset;
+        _shortestSectionDimension = leadingInset;
 
         NSMutableArray *sections = [NSMutableArray arrayWithCapacity:_sectionCount];
         for (NSUInteger i = 0; i < _sectionCount; i++) {
@@ -59,7 +59,8 @@
 
 - (CGFloat)maxEdgeForAttributes:(UICollectionViewLayoutAttributes *)attributes;
 {
-    return self.isHorizontal ? CGRectGetMaxX(attributes.frame) : CGRectGetMaxY(attributes.frame);
+    CGFloat attributeMax = self.isHorizontal ? CGRectGetMaxX(attributes.frame) : CGRectGetMaxY(attributes.frame);
+    return MAX(attributeMax, self.leadingInset);
 }
 
 - (CGFloat)dimensionForSection:(NSUInteger)sectionIndex;
@@ -131,7 +132,7 @@
 
 - (void)updateShortestSection;
 {
-    CGFloat shortestSectionDimension = 0;
+    CGFloat shortestSectionDimension = self.leadingInset;
     self.shortestSection = [self shortestSectionUpTo:self.sectionCount dimension:&shortestSectionDimension];
     self.shortestSectionDimension = shortestSectionDimension;
 }
@@ -150,10 +151,7 @@
     CGFloat xOffset = self.orthogonalInset + self.centeringOffset + edgeX;
     CGFloat yOffset = [self dimensionForSection:sectionIndex];
 
-    if ([self.sections[sectionIndex] count] == 0) {
-        // Start all the sections with the content inset, specifically to offset for the header.
-        yOffset += self.leadingInset;
-    } else {
+    if ([self.sections[sectionIndex] count] != 0){
         // All other items get margin.
         yOffset += self.alternateItemMargin;
     }


### PR DESCRIPTION
Footer location was getting calculated to be in the wrong place if the longest/shortest sections hadn't yet been calculated.