### PR TITLE
Support a callback for when a sticky header is attached

### DIFF
--- a/ARCollectionViewMasonryLayout.h
+++ b/ARCollectionViewMasonryLayout.h
@@ -2,17 +2,22 @@
 
 @class ARCollectionViewMasonryLayout;
 
+/// An extension on UICollectionViewDelegateFlowLayout with some extras for the masonry.
+
 @protocol ARCollectionViewMasonryLayoutDelegate <UICollectionViewDelegateFlowLayout>
 
 /// If you have a vertical direction then this is the height
 /// and width for horizontal.
-
 - (CGFloat)collectionView:(UICollectionView *)collectionView layout:(ARCollectionViewMasonryLayout *)collectionViewLayout variableDimensionForItemAtIndexPath:(NSIndexPath *)indexPath;
 
 @optional
+
+/// The size of the sticky header if implemented
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout*)collectionViewLayout referenceSizeForStickyHeaderInSection:(NSInteger)section;
 
+/// A callback for when a sticky header has changed it's attatched state
 - (void)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout*)collectionViewLayout stickyHeaderHasChangedStickyness:(BOOL)isAttachedToLeadingEdge;
+
 @end
 
 typedef NS_ENUM(NSInteger, ARCollectionViewMasonryLayoutDirection){
@@ -34,6 +39,7 @@ extern NSString *const ARCollectionElementKindSectionStickyHeader;
 /// Create a layout with a direction
 - (instancetype)initWithDirection:(enum ARCollectionViewMasonryLayoutDirection)direction;
 
+/// Deprecated
 - (instancetype)init __attribute__((unavailable("Invoke the designated initializer initWithDirection: instead.")));
 
 /// Direction of the collection view layout. Set in the initializer.

--- a/ARCollectionViewMasonryLayout.h
+++ b/ARCollectionViewMasonryLayout.h
@@ -11,6 +11,8 @@
 
 @optional
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout*)collectionViewLayout referenceSizeForStickyHeaderInSection:(NSInteger)section;
+
+- (void)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout*)collectionViewLayout stickyHeaderHasChangedStickyness:(BOOL)isAttachedToLeadingEdge;
 @end
 
 typedef NS_ENUM(NSInteger, ARCollectionViewMasonryLayoutDirection){

--- a/ARCollectionViewMasonryLayout.m
+++ b/ARCollectionViewMasonryLayout.m
@@ -430,8 +430,12 @@ NSString *const ARCollectionElementKindSectionStickyHeader = @"ARCollectionEleme
     BOOL needsEverything = !CGSizeEqualToSize(newBounds.size, self.collectionView.bounds.size);
     context.invalidateFlowLayoutDelegateMetrics = needsEverything;
     if (needsEverything) {
-        [context invalidateSupplementaryElementsOfKind:UICollectionElementKindSectionFooter atIndexPaths:@[indexPathZero]];
-        [context invalidateSupplementaryElementsOfKind:UICollectionElementKindSectionHeader atIndexPaths:@[indexPathZero]];
+        if ([self footerDimensionAtIndexPath:indexPathZero] != NSNotFound) {
+            [context invalidateSupplementaryElementsOfKind:UICollectionElementKindSectionFooter atIndexPaths:@[indexPathZero]];
+        }
+        if ([self headerDimensionAtIndexPath:indexPathZero] != NSNotFound) {
+            [context invalidateSupplementaryElementsOfKind:UICollectionElementKindSectionHeader atIndexPaths:@[indexPathZero]];
+        }
     }
 
     // The sticky header should always be invalidated

--- a/ARCollectionViewMasonryLayout.m
+++ b/ARCollectionViewMasonryLayout.m
@@ -9,6 +9,8 @@ NSString *const ARCollectionElementKindSectionStickyHeader = @"ARCollectionEleme
 
 @property (nonatomic, assign) NSInteger itemCount;
 
+@property (nonatomic, assign) BOOL stickyHeaderIsScrolling;
+
 @property (nonatomic, strong) UICollectionViewLayoutAttributes *headerAttributes;
 @property (nonatomic, strong) UICollectionViewLayoutAttributes *footerAttributes;
 @property (nonatomic, strong) UICollectionViewLayoutAttributes *stickyHeaderAttributes;
@@ -381,6 +383,12 @@ NSString *const ARCollectionElementKindSectionStickyHeader = @"ARCollectionEleme
     NSIndexPath *indexPathZero = [NSIndexPath indexPathForRow:0 inSection:0];
     CGFloat maxDistanceFromLeadingEdge = [self headerDimensionAtIndexPath:indexPathZero];
     CGFloat edge = MAX(maxDistanceFromLeadingEdge, self.collectionView.contentOffset.y);
+
+    BOOL isScrolling = edge != maxDistanceFromLeadingEdge;
+    if (isScrolling != self.stickyHeaderIsScrolling && self.delegate && [self.delegate respondsToSelector:@selector(collectionView:layout:stickyHeaderHasChangedStickyness:)]) {
+        [self.delegate collectionView:self.collectionView layout:self stickyHeaderHasChangedStickyness:isScrolling];
+    }
+    self.stickyHeaderIsScrolling = isScrolling;
 
     CGSize stickySize = CGSizeZero;
     if (self.delegate && [self.delegate respondsToSelector:@selector(collectionView:layout:referenceSizeForStickyHeaderInSection:)]) {

--- a/ARCollectionViewMasonryLayout.podspec
+++ b/ARCollectionViewMasonryLayout.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name                = "ARCollectionViewMasonryLayout"
-  s.version             = "2.1.2"
-  s.summary             = "ARCollectionViewMasonryLayout is a UICollectionViewLayout subclass for creating flow-like layouts with dynamic widths or heights."
+  s.version             = "2.2.0"
+  s.summary             = "ARCollectionViewMasonryLayout is a UICollectionViewLayout subclass for creating masonry / pintrest / flow-like layouts with dynamic widths or heights."
   s.homepage            = "https://github.com/AshFurrow/ARCollectionViewMasonryLayout"
   s.screenshots         = "https://raw.githubusercontent.com/AshFurrow/ARCollectionViewMasonryLayout/master/Screenshots/ARCollectionViewMasonryLayout.png"
   s.license             = 'MIT'
-  s.author              = { "Orta Therox" => "orta.therox@gmail.com" }
+  s.author              = { "Orta Therox" => "orta.therox@gmail.com", "Ash Furrow" => "ash@ashfurrow.com" }
   s.social_media_url    = "http://twitter.com/orta"
   s.platform            = :ios
   s.platform            = :ios, '7.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-Next
+2.2.0
 -----
 
+- [#28](https://github.com/ashfurrow/ARCollectionViewMasonryLayout/pull/29): Sticky headers can offer a callback when they switch stickiness - [@orta](https://github.com/orta)
 - [#27](https://github.com/ashfurrow/ARCollectionViewMasonryLayout/pull/27): Add support for Sticky headers in the collectionview - [@orta](https://github.com/orta)
 - [#27](https://github.com/ashfurrow/ARCollectionViewMasonryLayout/pull/27): Careful layout cache invalidation, should be a big speed boost from previous builds. - [@orta](https://github.com/orta)
 

--- a/Demo/Demo/ARCollectionViewController.h
+++ b/Demo/Demo/ARCollectionViewController.h
@@ -14,4 +14,5 @@
 @property(assign) CGSize stickyHeaderSize;
 @property(assign) CGSize footerSize;
 @property(strong) NSArray *heightPerEntry;
+@property(assign) BOOL stickyHeaderIsAttached;
 @end

--- a/Demo/Demo/ARCollectionViewController.m
+++ b/Demo/Demo/ARCollectionViewController.m
@@ -118,4 +118,9 @@ static NSString *CellIdentifier = @"Cell";
     return [self.modelArray[indexPath.row] dimension];
 }
 
+- (void)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout stickyHeaderHasChangedStickyness:(BOOL)isAttachedToLeadingEdge
+{
+    self.stickyHeaderIsAttached = isAttachedToLeadingEdge;
+}
+
 @end

--- a/IntegrationTests/ARCollectionViewMasonryLayoutTests.m
+++ b/IntegrationTests/ARCollectionViewMasonryLayoutTests.m
@@ -336,6 +336,26 @@ describe(@"vertical layout", ^{
             expect(viewController.view).to.haveValidSnapshotNamed(@"showsTheStickyHeaderOverTheHeader");
         });
 
+        // We dupe the above test entirely, because of the FBSnapshot a lot of the more complex layout setup
+        // is done for us, and the method should be called correctly from that.
+
+        it(@"sends a delegate message for the sticky header", ^{
+            viewController.colorCount = 200;
+            viewController.headerSize = CGSizeMake(300, 30);
+            viewController.stickyHeaderSize = CGSizeMake(300, 60);
+
+            expect(viewController.stickyHeaderIsAttached).to.beFalsy();
+
+            [viewController beginAppearanceTransition:YES animated:NO];
+            [viewController endAppearanceTransition];
+            [viewController.collectionView scrollToItemAtIndexPath: [NSIndexPath indexPathForItem:3 inSection:0]
+                                                  atScrollPosition:UICollectionViewScrollPositionTop animated:NO];
+            expect(viewController.view).to.haveValidSnapshotNamed(@"showsTheStickyHeaderOverTheHeader");
+
+            
+            expect(viewController.stickyHeaderIsAttached).to.beTruthy();
+        });
+
     });
 
 });

--- a/README.md
+++ b/README.md
@@ -89,6 +89,44 @@ The masonry layout supports a fixed height header and footer that scroll along w
 }
 ```
 
+Sticky Headers
+------------------
+
+The layout supports having a custom sticky header ( similar to the ones in a `UITableView`. ) It behaves simiar to how Headers and footers work. However it needs the layout delegate to support `collectionView:layout:referenceSizeForStickyHeaderInSection:`. 
+
+``` objc
+
+- (UICollectionReusableView *)collectionView:(UICollectionView *)collectionView viewForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
+{
+    [..]
+    } if ([kind isEqualToString:ARCollectionElementKindSectionStickyHeader]) {
+        UICollectionReusableView *view = [collectionView dequeueReusableSupplementaryViewOfKind:kind withReuseIdentifier:kind forIndexPath:indexPath];
+        view.backgroundColor = [UIColor purpleColor];
+        return view;
+
+    }
+    [..]
+}
+
+
+- (CGSize)collectionView:(UICollectionView *)collectionView layout:(ARCollectionViewMasonryLayout *)collectionViewLayout referenceSizeForStickyHeaderInSection:(NSInteger)section
+{
+    return self.stickyHeaderSize;
+}
+
+
+```
+
+It also provides a callback incase you want to make transitions when the header is sticky or not:
+
+```
+- (void)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout stickyHeaderHasChangedStickyness:(BOOL)isAttachedToLeadingEdge
+{
+    NSLog(@"Attatched: %@", @(isAttachedToLeadingEdge));
+}
+
+```
+
 Demo Project
 ------------
 

--- a/_ARCollectionViewMasonryAttributesGrid.h
+++ b/_ARCollectionViewMasonryAttributesGrid.h
@@ -3,9 +3,13 @@
 /// This class uses ‘sections’ to indicate ‘columns’ in a vertical layout and ‘rows’ in a horizontal layout.
 @interface _ARCollectionViewMasonryAttributesGrid : NSObject
 
+/// All of the attributes
 @property (nonatomic, readonly) NSArray *allItemAttributes;
+
+/// So you can keep state easily.
 @property (nonatomic, readonly) CGFloat longestSectionDimension;
 
+/// Standard init function
 - (instancetype)initWithSectionCount:(NSUInteger)sectionCount
                         isHorizontal:(BOOL)isHorizontal
                         leadingInset:(CGFloat)leadingInset


### PR DESCRIPTION
* Also fixes a bug where you could get into a state where the app thinks you need a header/footer when you've not defined one in the delegate callbacks. This would assert.
* WIP cause no specs.